### PR TITLE
Add __getitem__ method to make SolrSearch objects subscribable.

### DIFF
--- a/scorched/search.py
+++ b/scorched/search.py
@@ -555,6 +555,15 @@ class BaseSearch(object):
                 result.more_like_these[key].docs)
         return result
 
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            start, rows = key, 1
+        elif isinstance(key, slice):
+            start, rows = key.start, key.stop-key.start
+        else:
+            raise TypeError('Subscript must be int or slice')
+        return self.paginate(start, rows).execute()
+
 
 class SolrSearch(BaseSearch):
 


### PR DESCRIPTION
In some instances, we wish to be able to make a `SolrSearch` object subscriptable, e.g. when using it with the `paginate` (https://pypi.python.org/pypi/paginate) module. This is easy to do, considering that `scorched` already handles pagination.

The proposed `__getitem__` method should be compatible with Python 2.6+.

