### PR TITLE
use compat.basestring over compat.str in date convert

### DIFF
--- a/scorched/dates.py
+++ b/scorched/dates.py
@@ -5,7 +5,7 @@ import pytz
 import re
 import scorched.exc
 
-from scorched.compat import str
+from scorched.compat import basestring
 from scorched.compat import python_2_unicode_compatible
 
 
@@ -85,7 +85,7 @@ class solr_date(object):
     def __init__(self, v):
         if isinstance(v, solr_date):
             self._dt_obj = v._dt_obj
-        elif isinstance(v, str):
+        elif isinstance(v, basestring):
             self._dt_obj = datetime_from_w3_datestring(v)
         elif hasattr(v, "strftime"):
             self._dt_obj = self.from_date(v)

--- a/scorched/tests/test_dates.py
+++ b/scorched/tests/test_dates.py
@@ -4,7 +4,6 @@ import pytz
 import unittest
 import scorched.exc
 
-from scorched.compat import str
 from scorched.dates import (solr_date, datetime_from_w3_datestring,
                             datetime_factory)
 
@@ -37,6 +36,7 @@ samples_from_strings = {
 
 
 def check_solr_date_from_date(s, date, canonical_date):
+    from scorched.compat import str
     assert str(solr_date(date)) == s, "Unequal representations of %r: %r and %r" % (
         date, str(solr_date(date)), s)
     check_solr_date_from_string(s, canonical_date)
@@ -89,3 +89,10 @@ class TestDates(unittest.TestCase):
         else:  # pragma: no cover
             self.assertFalse(s == "Foo")
         self.assertEqual(s.__repr__(), 'datetime.datetime(2009, 7, 23, 3, 24, 34, 376, tzinfo=<UTC>)')
+
+    def test_solr_date_from_str(self):
+        # str here is original str from python
+        self.assertTrue("'str'" in repr(str))
+        s = solr_date(str("2009-07-23T03:24:34.000376Z"))
+        self.assertEqual(s, solr_date(s))
+        self.assertTrue(s == s)


### PR DESCRIPTION
with this, using scorched with python2.7 you can use plain string for date instead of wrap or convert to unicode.