### PR TITLE
better check datetime dynamicfields

### DIFF
--- a/scorched/dates.py
+++ b/scorched/dates.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import datetime
+import fnmatch
 import math
 import pytz
 import re
@@ -129,3 +130,13 @@ class solr_date(object):
         except AttributeError:
             pass
         return self._dt_obj == other
+
+
+def is_datetime_field(name, datefields):
+    if name in datefields:
+        return True
+    for fieldpattern in [d for d in datefields if '*' in d]:
+        # XXX: there is better than fnmatch ?
+        if fnmatch.fnmatch(name, fieldpattern):
+            return True
+    return False

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -108,9 +108,7 @@ class SolrResult(object):
     def _prepare_docs(self, docs, datefields):
         for doc in docs:
             for name, value in list(doc.items()):
-                if name in datefields:
-                    doc[name] = scorched.dates.solr_date(value)._dt_obj
-                elif name.endswith(datefields):
+                if scorched.dates.is_datetime_field(name, datefields):
                     doc[name] = scorched.dates.solr_date(value)._dt_obj
         return docs
 

--- a/scorched/tests/dumps/request_w_facets.json
+++ b/scorched/tests/dumps/request_w_facets.json
@@ -32,6 +32,7 @@
         "price_c": "12.5,USD",
         "created_dt": "2009-07-23T03:24:34.000376Z",
         "modified": "2009-07-23T03:24:34.000376Z",
+        "not_a_datetime_field_modified": "name of this field ends with modified but is not a datetime",
         "pages_i": 384,
         "_version_": 1462456002687271000
       },

--- a/scorched/tests/test_response.py
+++ b/scorched/tests/test_response.py
@@ -21,7 +21,7 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_response(self):
         res = scorched.response.SolrResponse.from_json(
-            self.data, datefields=('_dt', 'modified'))
+            self.data, datefields=('*_dt', 'modified'))
         self.assertEqual(res.status, 0)
         self.assertEqual(res.QTime, 1)
         self.assertEqual(res.result.numFound, 3)


### PR DESCRIPTION
A different implementation for better guessing datetime dynamicfields.

With previous method (endswith) I had problem when a textfield name is something like "candidate" and a datetime field as name "date".