### PR TITLE
Add q.alt parameter to DisMax

### DIFF
--- a/scorched/search.py
+++ b/scorched/search.py
@@ -859,6 +859,7 @@ class DismaxOptions(Options):
         "tie": float,
         "bq": str,
         "bf": str,
+        "q.alt": str,
     }
 
     def __init__(self, original=None):


### PR DESCRIPTION
This is not quite complete – using the query parser here would be nice for example, and this only takes effect if the `q` parameter is empty, which is only possible with passing `DismaxString(" ")` at the moment.

But it's better than nothing :).