### PR TITLE
Add support for solr cursors

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -177,6 +177,19 @@ which takes two parameters, ``start`` and ``rows``:
 
     >>> si.query("black").paginate(start=10, rows=30)
 
+Cursors
+-------
+If you want to get all / a huge number of results, you should use cursors to get
+the results in smaller chunks. Due to the way this is implemented in Solr, your
+sort needs to include your uniqueKey field. The ``cursor()`` method returns a
+cursor that you can iterate over. Like ``execute()``, ``cursor()`` takes an
+optional ``constructor`` parameter. In addition you can pass ``rows`` to define
+how many results should be fetched from solr at once.
+
+::
+
+    >>> for item in si.query("black").sort_by('id').cursor(rows=100): ...
+
 Returning different fields
 --------------------------
 

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -90,6 +90,7 @@ class SolrResponse(collections.Sequence):
         self.spellcheck = doc.get("spellcheck", {})
         self.groups = doc.get('grouped', {})
         self.debug = doc.get('debug', {})
+        self.next_cursor_mark = doc.get('nextCursorMark')
         self.more_like_these = dict(
             (k, SolrResult.from_json(v, datefields))
             for (k, v) in list(doc.get('moreLikeThis', {}).items()))


### PR DESCRIPTION
This adds support for solr cursors (https://cwiki.apache.org/confluence/display/solr/Pagination+of+Results#PaginationofResults-FetchingALargeNumberofSortedResults:Cursors)