### PR TITLE
Adds hinting for list objects to the add method

### DIFF
--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -326,7 +326,7 @@ class SolrInterface(object):
     def add(self, docs, chunk=100, **kwargs):
         """
         :param docs: documents to be added
-        :type docs: dict
+        :type docs: dict | list
         :param chunk: optional -- size of chunks in witch the add command
         schould be splitted
         :type chunk: int


### PR DESCRIPTION
This change makes it so that the method docstring supports either lists or dicts. I ran into this issue when Intellij was unhappy because I was passing a list to the add method instead of a dict, as the method requested.

This fixes the linting issue in my IDE, and apparently, there's no standard on this (yet), so it should be a decent way to proceed. Here's the documentation for Intellij and PyCharm, where they describe the syntax that they prefer (they're usually pretty sane about these things):

https://www.jetbrains.com/help/pycharm/2016.1/type-hinting-in-pycharm.html#legacy 