### PR TITLE
Adds note about Solr 4.x being unsupported.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Following some major differences:
 
 - Python 3
 
-- Drops support for Solr 4.x.
+- Drops support for Solr < 4.3.0
 
 - ...
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ Following some major differences:
 
 - Python 3
 
+- Drops support for Solr 4.x.
+
 - ...
 
 


### PR DESCRIPTION
Solr 4.x doesn't work because it doesn't have the schema REST API. 

This is pretty important to mention because people like me (that are using ancient versions of Solr) can go in circles for a while before figuring out that it's just a version incompatibility, not their local set up.