### PR TITLE
Fixes issue #38, making multi-value date fields work

### DIFF
--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -318,7 +318,11 @@ class SolrInterface(object):
                 if value is None:
                     continue
                 if scorched.dates.is_datetime_field(name, self._datefields):
-                    value = str(scorched.dates.solr_date(value))
+                    if is_iter(value):
+                        value = [str(scorched.dates.solr_date(v)) for v in
+                                 value]
+                    else:
+                        value = str(scorched.dates.solr_date(value))
                 new_doc[name] = value
             prepared_docs.append(new_doc)
         return prepared_docs
@@ -327,8 +331,8 @@ class SolrInterface(object):
         """
         :param docs: documents to be added
         :type docs: dict
-        :param chunk: optional -- size of chunks in witch the add command
-        schould be splitted
+        :param chunk: optional -- size of chunks in which the add command
+        should be split
         :type chunk: int
         :param kwargs: optinal -- additional arguments
         :type kwargs: dict

--- a/scorched/tests/test_functional.py
+++ b/scorched/tests/test_functional.py
@@ -248,6 +248,19 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(res.result.docs[0][k], v)
 
     @scorched.testing.skip_unless_solr
+    def test_multi_value_dates(self):
+        dsn = os.environ.get("SOLR_URL", "http://localhost:8983/solr")
+        si = SolrInterface(dsn)
+        docs = {
+            "id": "978-0641723445",
+            "important_dts": [
+                "1969-01-01",
+                "1969-01-02",
+            ],
+        }
+        si.add(docs)
+
+    @scorched.testing.skip_unless_solr
     def test_debug(self):
         dsn = os.environ.get("SOLR_URL",
                              "http://localhost:8983/solr")


### PR DESCRIPTION
This is a pretty simple PR to make `add`ing multi-value date fields possible, including a simple test.

The changes here do two things:

 - Check if the value of a date field is an iterable. If so, treats it as such.
 - Adds a test that uses a dynamic field to try to add a multi-value date to the index. It fails before this commit, but works afterwards.