### PR TITLE
Issue 41 highlighting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,13 @@
-0.10.3 (unreleased)
+0.10.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+ - Nothing changed yet.
+
+0.10.3 (2016-10-04)
+-------------------
+
+- Highlighting is now available in the result documents as the
+``solr_highlights`` field (mlissner)
 
 
 0.10.2 (2016-09-27)
@@ -57,7 +63,7 @@
 
 - Test against solr 4.10.2 and added python 3.4 to travis.
 
-- Added support for dismax queries. 
+- Added support for dismax queries.
 
 - Added support edismax field aliases.
 
@@ -125,6 +131,6 @@
 
 - Removed mx.DateTime
 
-- Removed redundant more_like_this  
+- Removed redundant more_like_this
 
 - Offspring of sunburnt is born

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -642,6 +642,10 @@ It is also possible to specify a array of fields::
     >>> si.query('thief').highlight(['name', 'title']).options()
     {'hl': True, 'hl.fl': 'name,title', 'q': u'thief'}
 
+Highlighting values will also be included in ``response.result.doc` as a
+``solr_highlights` attribute so that they can be accessed during result
+iteration.
+
 PostingsHighlighter
 -------------------
 

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -642,8 +642,8 @@ It is also possible to specify a array of fields::
     >>> si.query('thief').highlight(['name', 'title']).options()
     {'hl': True, 'hl.fl': 'name,title', 'q': u'thief'}
 
-Highlighting values will also be included in ``response.result.doc` as a
-``solr_highlights` attribute so that they can be accessed during result
+Highlighting values will also be included in ``response.result.doc` and grouped
+results as a ``solr_highlights` attribute so that they can be accessed during result
 iteration.
 
 PostingsHighlighter

--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -460,7 +460,10 @@ class SolrInterface(object):
         """
         params = scorched.search.params_from_dict(**kwargs)
         ret = scorched.response.SolrResponse.from_json(
-            self.conn.select(params), self._datefields)
+            self.conn.select(params),
+            self.schema['uniqueKey'],
+            self._datefields,
+        )
         return ret
 
     def query(self, *args, **kwargs):
@@ -483,7 +486,10 @@ class SolrInterface(object):
         """
         params = scorched.search.params_from_dict(**kwargs)
         ret = scorched.response.SolrResponse.from_json(
-            self.conn.mlt(params, content=content), self._datefields)
+            self.conn.mlt(params, content=content),
+            self.schema['uniqueKey'],
+            self._datefields,
+        )
         return ret
 
     def mlt_query(self, fields, content=None, content_charset=None,

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -114,7 +114,7 @@ class SolrResponse(collections.Sequence):
         self.highlighting = doc.get("highlighting", {})
         if self.highlighting:
             for d in self.result.docs:
-                k = d[unique_key]
+                k = str(d[unique_key])
                 if k in self.highlighting:
                     d['solr_highlights'] = self.highlighting[k]
         self.spellcheck = doc.get("spellcheck", {})

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -4,6 +4,7 @@ import json
 import scorched.dates
 
 from scorched.compat import str
+from scorched.search import is_iter
 
 
 class SolrFacetCounts(object):
@@ -206,7 +207,11 @@ class SolrResult(object):
         for doc in docs:
             for name, value in list(doc.items()):
                 if scorched.dates.is_datetime_field(name, datefields):
-                    doc[name] = scorched.dates.solr_date(value)._dt_obj
+                    if is_iter(value):
+                        doc[name] = [scorched.dates.solr_date(v)._dt_obj for
+                                     v in value]
+                    else:
+                        doc[name] = scorched.dates.solr_date(value)._dt_obj
         return docs
 
     def __str__(self):
@@ -236,7 +241,11 @@ class SolrGroupResult(object):
             for doc in group['doclist']['docs']:
                 for name, value in doc.items():
                     if scorched.dates.is_datetime_field(name, datefields):
-                        doc[name] = scorched.dates.solr_date(value)._dt_obj
+                        if is_iter(value):
+                            doc[name] = [scorched.dates.solr_date(v)._dt_obj for
+                                         v in value]
+                        else:
+                            doc[name] = scorched.dates.solr_date(value)._dt_obj
         return groups
 
     def __str__(self):

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -111,14 +111,30 @@ class SolrResponse(collections.Sequence):
         # if doc.get('match'):
         #    self.result = SolrResult.from_json(doc['match'], datefields)
         self.facet_counts = SolrFacetCounts.from_json(doc)
+        self.spellcheck = doc.get("spellcheck", {})
+        if self.params is not None:
+            self.group_field = self.params.get('group.field')
+        else:
+            self.group_field = None
+        self.groups = {}
+        if self.group_field is not None:
+            self.groups = SolrGroupResult.from_json(
+                doc['grouped'], self.group_field, datefields)
         self.highlighting = doc.get("highlighting", {})
         if self.highlighting:
-            for d in self.result.docs:
-                k = str(d[unique_key])
-                if k in self.highlighting:
-                    d['solr_highlights'] = self.highlighting[k]
-        self.spellcheck = doc.get("spellcheck", {})
-        self.groups = doc.get('grouped', {})
+            # Add highlighting info to the individual documents.
+            if doc.get('response'):
+                for d in self.result.docs:
+                    k = str(d[unique_key])
+                    if k in self.highlighting:
+                        d['solr_highlights'] = self.highlighting[k]
+            elif doc.get('grouped'):
+                for group in getattr(self.groups, self.group_field)['groups']:
+                    for d in group['doclist']['docs']:
+                        k = str(d[unique_key])
+                        if k in self.highlighting:
+                            d['solr_highlights'] = self.highlighting[k]
+
         self.debug = doc.get('debug', {})
         self.next_cursor_mark = doc.get('nextCursorMark')
         self.more_like_these = dict(
@@ -134,6 +150,7 @@ class SolrResponse(collections.Sequence):
     def from_get_json(cls, jsonmsg, datefields=()):
         """Generate instance from the response of a RealTime Get"""
         self = cls()
+        self.groups = {}
         self.original_json = jsonmsg
         doc = json.loads(jsonmsg)
         self.result = SolrResult.from_json(doc['response'], datefields)
@@ -160,10 +177,16 @@ class SolrResponse(collections.Sequence):
         return str(self.result)
 
     def __len__(self):
-        return len(self.result.docs)
+        if self.groups:
+            return len(getattr(self.groups, self.group_field)['groups'])
+        else:
+            return len(self.result.docs)
 
     def __getitem__(self, key):
-        return self.result.docs[key]
+        if self.groups:
+            return getattr(self.groups, self.group_field)['groups'][key]
+        else:
+            return self.result.docs[key]
 
 
 class SolrResult(object):
@@ -178,7 +201,8 @@ class SolrResult(object):
         self.docs = self._prepare_docs(docs, datefields)
         return self
 
-    def _prepare_docs(self, docs, datefields):
+    @staticmethod
+    def _prepare_docs(docs, datefields):
         for doc in docs:
             for name, value in list(doc.items()):
                 if scorched.dates.is_datetime_field(name, datefields):
@@ -188,3 +212,35 @@ class SolrResult(object):
     def __str__(self):
         return "{numFound} results found, starting at #{start}".format(
             numFound=self.numFound, start=self.start)
+
+
+class SolrGroupResult(object):
+
+    @classmethod
+    def from_json(cls, node, group_field, datefields=()):
+        self = cls()
+        self.name = 'response'
+        self.group_field = group_field
+        groups = node[group_field]['groups']
+        setattr(self, group_field, {
+            'matches': node[group_field]['matches'],
+            'ngroups': node[group_field]['ngroups'],
+            'groups': self._prepare_groups(groups, datefields),
+        })
+        return self
+
+    @staticmethod
+    def _prepare_groups(groups, datefields):
+        """Iterate over the docs and the groups and cast fields appropriately"""
+        for group in groups:
+            for doc in group['doclist']['docs']:
+                for name, value in doc.items():
+                    if scorched.dates.is_datetime_field(name, datefields):
+                        doc[name] = scorched.dates.solr_date(value)._dt_obj
+        return groups
+
+    def __str__(self):
+        return "{ngroups} groups with {matches} matches found".format(
+            ngroups=getattr(self, self.group_field)['ngroups'],
+            matches=getattr(self, self.group_field)['matches'],
+        )

--- a/scorched/response.py
+++ b/scorched/response.py
@@ -95,7 +95,7 @@ class SolrUpdateResponse(object):
 class SolrResponse(collections.Sequence):
 
     @classmethod
-    def from_json(cls, jsonmsg, datefields=()):
+    def from_json(cls, jsonmsg, unique_key, datefields=()):
         self = cls()
         self.original_json = jsonmsg
         doc = json.loads(jsonmsg)
@@ -112,6 +112,11 @@ class SolrResponse(collections.Sequence):
         #    self.result = SolrResult.from_json(doc['match'], datefields)
         self.facet_counts = SolrFacetCounts.from_json(doc)
         self.highlighting = doc.get("highlighting", {})
+        if self.highlighting:
+            for d in self.result.docs:
+                k = d[unique_key]
+                if k in self.highlighting:
+                    d['solr_highlights'] = self.highlighting[k]
         self.spellcheck = doc.get("spellcheck", {})
         self.groups = doc.get('grouped', {})
         self.debug = doc.get('debug', {})

--- a/scorched/tests/dumps/request_hl.json
+++ b/scorched/tests/dumps/request_hl.json
@@ -1,0 +1,43 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "author:John",
+      "hl": "true",
+      "hl.fl": "author",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "docs": [
+      {
+        "name": "The Höhlentripp Strauß",
+        "author": "John Muir",
+        "author_s": "John Muir",
+        "series_t": "Percy Jackson and ☂nicode",
+        "pages_i": 384,
+        "genre_s": "fantasy",
+        "id": "978",
+        "sequence_i": 1,
+        "inStock": true,
+        "cat": [
+          "book",
+          "hardcover"
+        ],
+        "price": 12.5,
+        "price_c": "12.5,USD",
+        "_version_": 1547482048566919168
+      }
+    ]
+  },
+  "highlighting": {
+    "978": {
+      "author": [
+        "<em>John</em> Muir"
+      ]
+    }
+  }
+}

--- a/scorched/tests/dumps/request_hl_grouped.json
+++ b/scorched/tests/dumps/request_hl_grouped.json
@@ -1,0 +1,53 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "author:Muir",
+      "hl": "true",
+      "hl.fl": "author",
+      "group.ngroups": "true",
+      "wt": "json",
+      "group.field": "inStock",
+      "group": "true"
+    }
+  },
+  "grouped": {
+    "inStock": {
+      "matches": 2,
+      "ngroups": 1,
+      "groups": [
+        {
+          "groupValue": true,
+          "doclist": {
+            "numFound": 2,
+            "start": 0,
+            "docs": [
+              {
+                "name": "The Yosemite",
+                "author": "John Muir",
+                "author_s": "John Muir",
+                "price": 12.5,
+                "price_c": "12.5,USD",
+                "important_dts": [
+                  "1969-01-01T00:00:00Z",
+                  "1969-01-02T00:00:00Z"
+                ],
+                "inStock": true,
+                "id": "978",
+                "_version_": 1547485322340728832
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "highlighting": {
+    "978": {
+      "author": [
+        "John <em>Muir</em>"
+      ]
+    }
+  }
+}

--- a/scorched/tests/test_functional.py
+++ b/scorched/tests/test_functional.py
@@ -261,6 +261,38 @@ class TestUtils(unittest.TestCase):
         si.add(docs)
 
     @scorched.testing.skip_unless_solr
+    def test_highlighting(self):
+        dsn = os.environ.get("SOLR_URL", 'http://localhost:8983/solr')
+        si = SolrInterface(dsn)
+        docs = {
+            "id": "978-0641723445",
+            "cat": ["book", "hardcover"],
+            "name": u"The Höhlentripp Strauß",
+            "author": u"Röüß Itoa",
+            "series_t": u"Percy Jackson and \N{UMBRELLA}nicode",
+            "sequence_i": 1,
+            "genre_s": "fantasy",
+            "inStock": True,
+            "price": 12.50,
+            "pages_i": 384
+        }
+        si.add(docs)
+        si.commit()
+        res = si.query(author=u"Röüß").highlight('author').execute()
+        highlighted_field_result = u'<em>Röüß</em> Itoa'
+        # Does the highlighting attribute work?
+        self.assertEqual(
+            res.highlighting['978-0641723445']['author'][0],
+            highlighted_field_result,
+        )
+
+        # Does each item have highlighting attributes?
+        self.assertEqual(
+            res.result.docs[0]['solr_highlights']['author'][0],
+            highlighted_field_result,
+        )
+
+    @scorched.testing.skip_unless_solr
     def test_debug(self):
         dsn = os.environ.get("SOLR_URL",
                              "http://localhost:8983/solr")

--- a/scorched/tests/test_functional.py
+++ b/scorched/tests/test_functional.py
@@ -252,13 +252,15 @@ class TestUtils(unittest.TestCase):
         dsn = os.environ.get("SOLR_URL", "http://localhost:8983/solr")
         si = SolrInterface(dsn)
         docs = {
-            "id": "978-0641723445",
+            "id": "978",
             "important_dts": [
                 "1969-01-01",
                 "1969-01-02",
             ],
         }
         si.add(docs)
+        si.commit()
+        _ = si.query(id=u"978").execute()
 
     @scorched.testing.skip_unless_solr
     def test_highlighting(self):

--- a/scorched/tests/test_response.py
+++ b/scorched/tests/test_response.py
@@ -9,20 +9,30 @@ import scorched.response
 class ResultsTestCase(unittest.TestCase):
 
     def setUp(self):
-        file = os.path.join(os.path.dirname(__file__), "dumps",
-                            "request_w_facets.json")
-        with open(file) as f:
+        file_path = os.path.join(os.path.dirname(__file__), "dumps",
+                                 "request_w_facets.json")
+        with open(file_path) as f:
             self.data = f.read()
         # termVector data
-        file = os.path.join(os.path.dirname(__file__), "dumps",
-                            "request_w_termvector.json")
-        with open(file) as f:
+        file_path = os.path.join(os.path.dirname(__file__), "dumps",
+                                 "request_w_termvector.json")
+        with open(file_path) as f:
             self.data_tv = f.read()
         # error data
-        file = os.path.join(os.path.dirname(__file__), "dumps",
-                            "request_error.json")
-        with open(file) as f:
+        file_path = os.path.join(os.path.dirname(__file__), "dumps",
+                                 "request_error.json")
+        with open(file_path) as f:
             self.data_error = f.read()
+
+        file_path = os.path.join(os.path.dirname(__file__), "dumps",
+                                 "request_hl.json")
+        with open(file_path) as f:
+            self.data_hl = f.read()
+
+        file_path = os.path.join(os.path.dirname(__file__), "dumps",
+                                 "request_hl_grouped.json")
+        with open(file_path) as f:
+            self.data_hl_grouped = f.read()
 
     def test_response(self):
         res = scorched.response.SolrResponse.from_json(
@@ -65,8 +75,13 @@ class ResultsTestCase(unittest.TestCase):
                           },
                           'facet_pivot': ()})
 
+        self.assertRaises(ValueError, res.from_json, self.data_error, 'id')
+        self.assertEqual(res.__str__(), u'3 results found, starting at #0')
+        self.assertEqual(len(res), 3)
+
+    def test_term_vectors(self):
         res_tv = scorched.response.SolrResponse.from_json(
-            self.data_tv, 'id', datefields=('date'))
+            self.data_tv, 'id', datefields=('date',))
         self.assertEqual(res_tv.term_vectors["uniqueKeyFieldName"], "uid")
         self.assertEqual(res_tv.term_vectors["warnings"],
                          {"noTermVectors": ["title"]})
@@ -77,6 +92,29 @@ class ResultsTestCase(unittest.TestCase):
         self.assertEqual(res_tv.term_vectors["9ce8ef2d-6e0f-5647-ae4c-2aaaca37b28f"]["weighted_words"]["anlagen"],
                          {"tf": 3, "df": 21484})
 
-        self.assertRaises(ValueError, res.from_json, self.data_error, 'id')
-        self.assertEqual(res.__str__(), u'3 results found, starting at #0')
-        self.assertEqual(len(res), 3)
+    def test_highlighting(self):
+        res_hl = scorched.response.SolrResponse.from_json(
+            self.data_hl, 'id')
+        highlights = {u'author': [u'<em>John</em> Muir']}
+        self.assertEqual(res_hl.highlighting['978'], highlights)
+        self.assertEqual(res_hl.result.docs[0]['solr_highlights'], highlights)
+
+    def test_highlighting_with_grouping(self):
+        res_hl_group = scorched.response.SolrResponse.from_json(
+            self.data_hl_grouped, 'id', datefields=('important_dts',))
+        self.assertEqual(res_hl_group.group_field, 'inStock')
+        self.assertEqual(getattr(res_hl_group.groups, res_hl_group.group_field)['matches'], 2)
+        ngroups = getattr(res_hl_group.groups, res_hl_group.group_field)['ngroups']
+        self.assertEqual(ngroups, 1)
+
+        groups = getattr(res_hl_group.groups, res_hl_group.group_field)['groups']
+        self.assertEqual(len(groups), ngroups)
+
+        highlights = {u'author': [u'John <em>Muir</em>']}
+        self.assertEqual(groups[0]['doclist']['docs'][0]['solr_highlights'],
+                         highlights)
+        self.assertEqual(type(groups[0]['doclist']['docs'][0]['important_dts'][0]),
+                         datetime.datetime)
+
+
+

--- a/scorched/tests/test_response.py
+++ b/scorched/tests/test_response.py
@@ -26,7 +26,7 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_response(self):
         res = scorched.response.SolrResponse.from_json(
-            self.data, datefields=('*_dt', 'modified'))
+            self.data, 'id', datefields=('*_dt', 'modified'))
         self.assertEqual(res.status, 0)
         self.assertEqual(res.QTime, 1)
         self.assertEqual(res.result.numFound, 3)
@@ -66,7 +66,7 @@ class ResultsTestCase(unittest.TestCase):
                           'facet_pivot': ()})
 
         res_tv = scorched.response.SolrResponse.from_json(
-            self.data_tv, datefields=('date'))
+            self.data_tv, 'id', datefields=('date'))
         self.assertEqual(res_tv.term_vectors["uniqueKeyFieldName"], "uid")
         self.assertEqual(res_tv.term_vectors["warnings"],
                          {"noTermVectors": ["title"]})
@@ -77,6 +77,6 @@ class ResultsTestCase(unittest.TestCase):
         self.assertEqual(res_tv.term_vectors["9ce8ef2d-6e0f-5647-ae4c-2aaaca37b28f"]["weighted_words"]["anlagen"],
                          {"tf": 3, "df": 21484})
 
-        self.assertRaises(ValueError, res.from_json, self.data_error)
+        self.assertRaises(ValueError, res.from_json, self.data_error, 'id')
         self.assertEqual(res.__str__(), u'3 results found, starting at #0')
         self.assertEqual(len(res), 3)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import os
 from setuptools import setup, find_packages
 
-version = '0.10.3.dev0'
+version = '0.10.4.dev0'
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()


### PR DESCRIPTION
This should fix issue #41 by mirroring the `solr_highlighting` attribute that was available in Sunburnt. I had to make a small tweak to the `from_json` method so that it would know the correct unique key, but otherwise I think this is a fairly straightforward fix. 

Also includes tests, and I bumped the version and change log, in hopes of making your job easier.

Please let me know what you think. 