### PR TITLE
Fixes issue #45 by using attributes of the reponse

### DIFF
--- a/scorched/response.py
+++ b/scorched/response.py
@@ -179,9 +179,9 @@ class SolrResponse(collections.Sequence):
 
     def __len__(self):
         if self.groups:
-            return len(getattr(self.groups, self.group_field)['groups'])
+            return getattr(self.groups, self.group_field)['ngroups']
         else:
-            return len(self.result.docs)
+            return self.result.numFound
 
     def __getitem__(self, key):
         if self.groups:


### PR DESCRIPTION
This fixes issue 45 so that the `__len__` method uses attributes of the Solr response instead of counting the number of rows returned. In the old method, if `rows=0`, the SolrResponse would have a `__len__` of zero. This made pagination and other things difficult. Even if `rows=20`, that'd be the highest length that the SolrResponse would have.

In this fix, the number of groups or the number of results is returned instead.