### PR TITLE
Second approach at fixing issue 45

### DIFF
--- a/scorched/search.py
+++ b/scorched/search.py
@@ -570,6 +570,22 @@ class BaseSearch(object):
                 result.more_like_these[key].docs)
         return result
 
+    _count = None
+    def count(self):
+        if self._count is None:
+            # We haven't gotten the count yet. Get it. Clone self for this
+            # query or else we'll set rows=0 for remainder.
+            newself = self.clone()
+            r = newself.paginate(None, 0).execute()
+            if r.groups:
+                total = getattr(r.groups, r.group_field)['ngroups']
+            else:
+                total = r.result.numFound
+
+            # Set the cache
+            self._count = total
+        return self._count
+
     def __getitem__(self, key):
         if isinstance(key, int):
             start, rows = key, 1

--- a/scorched/tests/test_functional.py
+++ b/scorched/tests/test_functional.py
@@ -295,6 +295,26 @@ class TestUtils(unittest.TestCase):
         )
 
     @scorched.testing.skip_unless_solr
+    def test_count(self):
+        dsn = os.environ.get("SOLR_URL", "http://localhost:8983/solr")
+        si = SolrInterface(dsn)
+        docs = [{
+            "id": "1",
+            "genre_s": "fantasy",
+        }, {
+            "id": "2",
+            "genre_s": "fantasy",
+        }]
+        si.add(docs)
+        si.commit()
+        ungrouped_count = si.query(genre_s="fantasy").count()
+        ungrouped_count_expected = 2
+        self.assertEqual(ungrouped_count, ungrouped_count_expected)
+        grouped_count = si.query(genre_s="fantasy").group_by("genre_s").count()
+        grouped_count_expected = 1
+        self.assertEqual(grouped_count, grouped_count_expected)
+
+    @scorched.testing.skip_unless_solr
     def test_debug(self):
         dsn = os.environ.get("SOLR_URL",
                              "http://localhost:8983/solr")
@@ -338,6 +358,13 @@ class TestMltHandler(unittest.TestCase):
         with open(file) as f:
             self.datajson = f.read()
             self.docs = json.loads(self.datajson)
+
+    def tearDown(self):
+        dsn = os.environ.get("SOLR_URL",
+                             "http://localhost:8983/solr")
+        si = SolrInterface(dsn)
+        si.delete_all()
+        si.commit()
 
     @scorched.testing.skip_unless_solr
     def test_mlt(self):


### PR DESCRIPTION
This is a second approach to fixing issue #45, since the last attempt got rather messy. This gets the whole thing into a single commit with one added method on `BaseSearch`, and a couple of simple tests.

I ran into one issue with the MLT functional tests, which weren't cleaning up after themselves, so I tweaked that too. Otherwise, I think this is a good, clean solution.

(As an aside, this is nearly identical to what we've been using in production for a few weeks.)