### PR TITLE
Allow user to pass an http_connection to SolrInterface ctor

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -11,3 +11,4 @@ Contributors
 
 - Mike Lissner
 
+- Thomas Quinot

--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -395,7 +395,7 @@ class SolrInterface(object):
         A commit operation makes index changes visible to new search requests.
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"commit": {}}', commit=True,
+            self.conn.update(b'{"commit": {}}', commit=True,
                              waitSearcher=waitSearcher,
                              expungeDeletes=expungeDeletes,
                              softCommit=softCommit))
@@ -416,7 +416,7 @@ class SolrInterface(object):
         index segments to be merged into a single segment first.
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"optimize": {}}', optimize=True,
+            self.conn.update(b'{"optimize": {}}', optimize=True,
                              waitSearcher=waitSearcher,
                              maxSegments=maxSegments))
         return ret
@@ -429,7 +429,7 @@ class SolrInterface(object):
         the last commit
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"rollback": {}}'))
+            self.conn.update(b'{"rollback": {}}'))
         return ret
 
     def delete_all(self):

--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -30,7 +30,8 @@ class SolrConnection(object):
         """
         :param url: url to Solr
         :type url: str
-        :param http_connection: already existing connection TODO
+        :param http_connection: existing requests.Session object, or None to
+                                create a new one.
         :type http_connection: requests connection
         :param mode: mode (readable, writable) Solr
         :type mode: str
@@ -43,7 +44,7 @@ class SolrConnection(object):
                                (connect timeout, read timeout) tuple.
         :type search_timeout: float or tuple
         """
-        self.http_connection = requests.Session()
+        self.http_connection = http_connection or requests.Session()
         if mode == 'r':
             self.writeable = False
         elif mode == 'w':
@@ -271,7 +272,7 @@ class SolrInterface(object):
         """
         :param url: url to Solr
         :type url: str
-        :param http_connection: optional -- already existing connection TODO
+        :param http_connection: optional -- already existing connection
         :type http_connection: requests connection
         :param mode: optional -- mode (readable, writable) Solr
         :type mode: str


### PR DESCRIPTION
This allows the user to set any required HTTP parameters on the session (such as Basic auth credentials, or SSL verification parameters). This used to be supported in suburnt, and is essential if your Solr server requires authentication.