### PR TITLE
SSL connection requires byte strings, not Unicode literals

### DIFF
--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -394,7 +394,7 @@ class SolrInterface(object):
         A commit operation makes index changes visible to new search requests.
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"commit": {}}', commit=True,
+            self.conn.update(b'{"commit": {}}', commit=True,
                              waitSearcher=waitSearcher,
                              expungeDeletes=expungeDeletes,
                              softCommit=softCommit))
@@ -415,7 +415,7 @@ class SolrInterface(object):
         index segments to be merged into a single segment first.
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"optimize": {}}', optimize=True,
+            self.conn.update(b'{"optimize": {}}', optimize=True,
                              waitSearcher=waitSearcher,
                              maxSegments=maxSegments))
         return ret
@@ -428,7 +428,7 @@ class SolrInterface(object):
         the last commit
         """
         ret = scorched.response.SolrUpdateResponse.from_json(
-            self.conn.update('{"rollback": {}}'))
+            self.conn.update(b'{"rollback": {}}'))
         return ret
 
     def delete_all(self):


### PR DESCRIPTION
Fix type of JSON string literals for administrative commands (commit,
optimize, rollback).