### PR TITLE
Allow user to pass an http_connection to SolrInterface ctor

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -11,3 +11,4 @@ Contributors
 
 - Mike Lissner
 
+- Thomas Quinot

--- a/scorched/connection.py
+++ b/scorched/connection.py
@@ -30,7 +30,8 @@ class SolrConnection(object):
         """
         :param url: url to Solr
         :type url: str
-        :param http_connection: already existing connection TODO
+        :param http_connection: existing requests.Session object, or None to
+                                create a new one.
         :type http_connection: requests connection
         :param mode: mode (readable, writable) Solr
         :type mode: str
@@ -43,7 +44,7 @@ class SolrConnection(object):
                                (connect timeout, read timeout) tuple.
         :type search_timeout: float or tuple
         """
-        self.http_connection = requests.Session()
+        self.http_connection = http_connection or requests.Session()
         if mode == 'r':
             self.writeable = False
         elif mode == 'w':
@@ -271,7 +272,7 @@ class SolrInterface(object):
         """
         :param url: url to Solr
         :type url: str
-        :param http_connection: optional -- already existing connection TODO
+        :param http_connection: optional -- already existing connection
         :type http_connection: requests connection
         :param mode: optional -- mode (readable, writable) Solr
         :type mode: str

--- a/scorched/tests/test_connection.py
+++ b/scorched/tests/test_connection.py
@@ -148,6 +148,17 @@ class TestConnection(unittest.TestCase):
         sc.search_timeout = (1.0, 5.0)
         self.assertRaises(requests.exceptions.ConnectTimeout, sc.select, [])
 
+    def test_basic_auth(self):
+        hc = requests.Session()
+        hc.auth = ('joe', 'Secret')
+
+        dsn = "http://localhost:1234/none"
+        sc = self._make_connection(url=dsn, http_connection=hc)
+        sc.select_url = httpbin('/basic-auth/{0}/{1}'.format(*hc.auth))
+
+        resp = sc.select([])
+        self.assertTrue(json.loads(resp)['authenticated'])
+
 
 class TestSolrInterface(unittest.TestCase):
 


### PR DESCRIPTION
This allows the user to set any required HTTP parameters on the session (such as Basic auth credentials, or SSL verification parameters).