### PR TITLE
Add missing mlt parameter

### DIFF
--- a/scorched/search.py
+++ b/scorched/search.py
@@ -1040,6 +1040,7 @@ class MoreLikeThisOptions(Options):
     opts = {"count": int,
             "mintf": int,
             "mindf": int,
+            "maxdf": int,
             "minwl": int,
             "maxwl": int,
             "maxqt": int,


### PR DESCRIPTION
I'm not sure why this option for More Like This is missing. It looks like it's missing from sunburnt as well (I think we vendored sunburnt to fix this back when we used that). 

Anyway, this is just a one line change. 

I think this is the one thing preventing our py3 upgrade. If I can help release a new version with this change, I'd love to do so.